### PR TITLE
Added in a 'val' method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ cm.set('name', 'value', {
   domain: [domain] // e.g. '.foo.com'
 })
 ```
+### val
+Return the first value of a cookie that has been set on the page, or null if the cookie is not present
+```javascript
+cm.val('name')
+```
 
 ### cookies
 Get an array of all available cookies

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -124,7 +124,7 @@ function clearAll (name) {
 function cookieValue (name) {
   var val = null
   var cookies = getCookie(name)
-  if (cookies && cookies[0] && cookies[0].value) {
+  if (cookies && cookies[0] && (cookies[0].value || cookies[0].value === '')) {
     val = cookies[0].value
   }
   return val

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -123,9 +123,10 @@ function clearAll (name) {
  */
 function cookieValue (name) {
   var val = null
-  try {
-    val = getCookie(name)[0].value
-  } catch (e) {}
+  var cookies = getCookie(name)
+  if (cookies && cookies[0] && cookies[0].value) {
+    val = cookies[0].value
+  }
   return val
 }
 

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -122,10 +122,8 @@ function clearAll (name) {
  * @returns {Null} or {Boolean} Returns null if the cookie is not found or the cookie's value
  */
 function cookieValue (name) {
-  var val = null
   var cookies = getCookie(name)
-  if (cookies && cookies[0]) val = cookies[0].value
-  return val
+  return cookies.length ? cookies[0].value : null
 }
 
 module.exports = {

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -124,9 +124,7 @@ function clearAll (name) {
 function cookieValue (name) {
   var val = null
   var cookies = getCookie(name)
-  if (cookies && cookies[0] && (cookies[0].value !== undefined || cookies[0].value !== null)) {
-    val = cookies[0].value
-  }
+  if (cookies && cookies[0]) val = cookies[0].value
   return val
 }
 

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -124,7 +124,7 @@ function clearAll (name) {
 function cookieValue (name) {
   var val = null
   var cookies = getCookie(name)
-  if (cookies && cookies[0] && (cookies[0].value || cookies[0].value === '')) {
+  if (cookies && cookies[0] && (cookies[0].value !== undefined || cookies[0].value !== null)) {
     val = cookies[0].value
   }
   return val

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -123,10 +123,9 @@ function clearAll (name) {
  */
 function cookieValue (name) {
   var val = null
-  var match = document.cookie.match(new RegExp(name + '=' + '([^;]+)'))
-  if (match && match[1]) {
-    val = match[1]
-  }
+  try {
+    val = getCookie(name)[0].value
+  } catch (e) {}
   return val
 }
 

--- a/lib/cookieman.js
+++ b/lib/cookieman.js
@@ -114,10 +114,27 @@ function clearAll (name) {
   return cleared
 }
 
+/**
+ * gets the value of a cookie, or returns null
+ *
+ * @public
+ * @param {String} name The cookie name
+ * @returns {Null} or {Boolean} Returns null if the cookie is not found or the cookie's value
+ */
+function cookieValue (name) {
+  var val = null
+  var match = document.cookie.match(new RegExp(name + '=' + '([^;]+)'))
+  if (match && match[1]) {
+    val = match[1]
+  }
+  return val
+}
+
 module.exports = {
   'get': getCookie,
   'set': setCookie,
   'cookies': getCookies,
   'clear': clearCookie,
-  'clearAll': clearAll
+  'clearAll': clearAll,
+  'val': cookieValue
 }

--- a/test/test-cookieman.js
+++ b/test/test-cookieman.js
@@ -216,5 +216,10 @@ describe('cookieman', function () {
       cookieman.set('sweety', 'darling', { path: '/cookie' })
       expect(cookieman.val('sweety')).to.eql('darling')
     })
+    it('should return the value of the first cookie if multiple cookies with the same name exists', function () {
+      cookieman.set('sweety', 'darling', { path: '/cookie' })
+      cookieman.set('sweety', 'pie', { path: '/' })
+      expect(cookieman.val('sweety')).to.eql('darling')
+    })
   })
 })

--- a/test/test-cookieman.js
+++ b/test/test-cookieman.js
@@ -186,7 +186,7 @@ describe('cookieman', function () {
       document.cookie = 'flippy=magoo; path=/cookie; expires=' + new Date(1).toUTCString()
     })
 
-    it("should clear cookies no matter what path/domain they're on", function () {
+    it('should clear cookies no matter what path/domain they\'re on', function () {
       cookieman.set('flippy', 'magoo', { path: '/cookie' })
       cookieman.clearAll('sweety')
       expect(cookieman.get('sweety')).to.have.length(0)
@@ -206,6 +206,15 @@ describe('cookieman', function () {
         path: null,
         domain: null
       }])
+    })
+  })
+  describe('val', function () {
+    it('should return null if no cookie with that name has been set', function () {
+      expect(cookieman.val('sweety')).to.eql(null)
+    })
+    it('should return the value of the cookie if the cookie exists', function () {
+      cookieman.set('sweety', 'darling', { path: '/cookie' })
+      expect(cookieman.val('sweety')).to.eql('darling')
     })
   })
 })

--- a/test/test-cookieman.js
+++ b/test/test-cookieman.js
@@ -221,5 +221,13 @@ describe('cookieman', function () {
       cookieman.set('sweety', 'pie', { path: '/' })
       expect(cookieman.val('sweety')).to.eql('darling')
     })
+    it('should return an empty string if that is the value of the cookie', function () {
+      cookieman.set('sweety', '', { path: '/cookie' })
+      expect(cookieman.val('sweety')).to.eql('')
+    })
+    it('should return null if the cookie had no value set', function () {
+      document.cookie = 'sweety=; path=/cookie; expires=' + new Date(1).toUTCString()
+      expect(cookieman.val('sweety')).to.eql(null)
+    })
   })
 })


### PR DESCRIPTION
Added in a 'val' method, to allow quick access to cookie values without having to use ```cm.get```. Returns either the cookie's value or ```null```.